### PR TITLE
fix: remove hardcoded default profile picture URL

### DIFF
--- a/create-admin.js
+++ b/create-admin.js
@@ -15,8 +15,7 @@ async function createAdmin() {
           email: "admin@carexpert.com",
           password: hashedPassword,
           role: "ADMIN",
-          profilePicture:
-            "https://res.cloudinary.com/de930by1y/image/upload/v1747403920/careXpert_profile_pictures/kxwsom57lcjamzpfjdod.jpg",
+          profilePicture: null,
         },
       });
 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -98,8 +98,7 @@ const signup = async (req: Request, res: any) => {
           email,
           password: hashedPassword,
           role,
-          profilePicture:
-            "https://res.cloudinary.com/de930by1y/image/upload/v1747403920/careXpert_profile_pictures/kxwsom57lcjamzpfjdod.jpg",
+          profilePicture: null,
         },
       });
 
@@ -224,8 +223,7 @@ const adminSignup = async (req: Request, res: any) => {
           email,
           password: hashedPassword,
           role: "ADMIN",
-          profilePicture:
-            "https://res.cloudinary.com/de930by1y/image/upload/v1747403920/careXpert_profile_pictures/kxwsom57lcjamzpfjdod.jpg",
+          profilePicture: null,
         },
       });
 


### PR DESCRIPTION
Team Number: Team 150
## Description

This PR removes hardcoded default profile picture URLs from the backend user creation flows.  
Newly created users now have `profilePicture` set to `null`, allowing the frontend to display default avatars using user initials.

## Related Issue
Closes #1 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Style/UI improvement

## Changes Made
- Updated `signup` flow in `src/controllers/user.controller.ts` to set `profilePicture: null` instead of a hardcoded Cloudinary URL.
- Updated `adminSignup` flow in `src/controllers/user.controller.ts` to set `profilePicture: null`.
- Updated `create-admin.js` to remove the hardcoded profile image URL and use `profilePicture: null`.

## Screenshots (if applicable)

**Before:**
All newly created users were assigned the same hardcoded profile image URL.

**After:**
New users are created without a profile picture (`null`), enabling frontend initials-based avatar fallback.

## Testing
- [ ] Tested on Desktop (Chrome/Firefox/Safari)
- [ ] Tested on Mobile (iOS/Android)
- [ ] Tested responsive design (different screen sizes)
- [x] No console errors or warnings
- [ ] Code builds successfully (`npm run build`)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] All TypeScript types are properly defined
- [ ] Tailwind CSS classes are used appropriately (no inline styles)
- [ ] Component is responsive across different screen sizes
- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

## Additional Notes
This is a backend-only change; UI fallback behavior (initials avatar) is expected to be handled by the frontend when `profilePicture` is `null`.