### PR TITLE
feat: Add bulk timeslot generation endpoint for doctors

### DIFF
--- a/src/Routes/doctor.routes.ts
+++ b/src/Routes/doctor.routes.ts
@@ -17,6 +17,7 @@ import {
   markNotificationAsRead,
   addPrescriptionToAppointment,
   markAppointmentCompleted,
+  generateBulkTimeSlots,
 } from "../controllers/doctor.controller";
 import { isDoctor } from "../utils/helper";
 import { isAuthenticated } from "../middlewares/auth.middleware";
@@ -24,6 +25,7 @@ import { isAuthenticated } from "../middlewares/auth.middleware";
 const router = Router();
 
 router.post("/add-timeslot", isAuthenticated, isDoctor, addTimeslot);
+router.post("/timeslots/bulk", isAuthenticated, isDoctor, generateBulkTimeSlots);
 router.get("/view-timeslots", isAuthenticated, isDoctor, viewTimeslots);
 
 router.get("/appointments", isAuthenticated, isDoctor, viewDoctorAppointment);


### PR DESCRIPTION
## Team Information
**Team Number**: Team 065

## Issue Details
Closes #8 
**Issue Number**: #08
**Issue Link**: [Link to issue #08]

## Description
Added bulk timeslot generation endpoint to allow doctors to create multiple timeslots in a single request.

## Changes Made
- Added `POST /api/doctor/timeslots/bulk` endpoint in doctor.routes.ts
- Created `generateBulkTimeSlots` method in doctor.controller.ts
- Accepts parameters: startDate, endDate, startTime, endTime, durationInMinutes
- Automatically splits time into chunks based on duration
- Prevents overlapping with existing slots

## Acceptance Criteria Met
- ✅ Doctor can generate multiple slots over a date range and time window
- ✅ System automatically splits time into correct durationInMinutes intervals
- ✅ Prevents overlapping (skips and reports conflicting slots)

## Testing
Tested with POST request to `/api/doctor/timeslots/bulk` endpoint