### PR TITLE
fix: configure CORS origin via environment variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const app = express();
 // app.use(cors()); // Remove default CORS middleware
 app.use(
   cors({
-    origin: "http://localhost:5173",
+    origin: process.env.CORS_ORIGIN || "http://localhost:5173",
     credentials: true,
   })
 );
@@ -56,7 +56,7 @@ const httpServer = http.createServer(app);
 
 const io = new Server(httpServer, {
   cors: {
-    origin: "http://localhost:5173",
+    origin: process.env.CORS_ORIGIN,
     methods: ["GET", "POST"],
     credentials: true,
   },


### PR DESCRIPTION
Team Number: Team 082
Closes #2

Description:
Replaced the hardcoded 'http://localhost:5173' CORS origin with process.env.CORS_ORIGIN in both Express and Socket.IO configurations to support different frontend URLs in production.