### PR TITLE
fix: include CONFIRMED status to prevent double booking

### DIFF
--- a/src/controllers/patient.controller.ts
+++ b/src/controllers/patient.controller.ts
@@ -222,7 +222,11 @@ const bookAppointment = async (req: any, res: Response): Promise<void> => {
       const existingAppointment = await prisma.appointment.findFirst({
         where: {
           status: {
-            in: [AppointmentStatus.COMPLETED, AppointmentStatus.PENDING],
+            in: [
+              AppointmentStatus.COMPLETED,
+              AppointmentStatus.PENDING,
+              AppointmentStatus.CONFIRMED,
+            ],
           },
           patientId: patient.id,
           timeSlot: {


### PR DESCRIPTION
**Team Number:** Team 170

**Issue Reference:** Closes #9

**Description:**
Updated the [bookAppointment](cci:1://file:///d:/GDG/CareXpert_backend/src/controllers/patient.controller.ts:163:0-312:2) controller function in [patient.controller.ts](cci:7://file:///d:/GDG/CareXpert_backend/src/controllers/patient.controller.ts:0:0-0:0). The query that checks for an `existingAppointment` now includes `AppointmentStatus.CONFIRMED` in the `status` array filter. This fix prevents patients from booking a slot at a time where they already have an appointment that is in either `COMPLETED`, `PENDING`, or `CONFIRMED` state.

**API Changes:**
No new APIs were created. Modified the existing POST appointment booking logic to prevent double-booking over confirmed time slots.
