### PR TITLE
fix: correct cookie name typo in logout - 'refresToken' to 'refreshTo… Team -T188

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -334,7 +334,7 @@ const logout = async (req: any, res: any) => {
     return res
       .status(200)
       .clearCookie("accessToken", options)
-      .clearCookie("refresToken", options)
+      .clearCookie("refreshToken", options)
       .json(new ApiResponse(200, "Logout successfully"));
   } catch (err) {
     return res.status(500).json(new ApiError(500, "internal server error"));


### PR DESCRIPTION
…ken'
## Team Number : Team 188
Fixes #25

The logout function was clearing a cookie named 'refresToken' (missing 'h'), but the login function sets the cookie as 'refreshToken'. This typo meant the refresh token cookie was never actually cleared on logout, leaving users vulnerable to session hijacking.

Changed 'refresToken' to 'refreshToken' in the clearCookie call.