### PR TITLE
Fix undefined hashedRefresh variable in token generation

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -22,6 +22,7 @@ const generateToken = async (userId: string) => {
 
     const accessToken = generateAccessToken(userId, user.tokenVersion);
     const refreshToken = generateRefreshToken(userId, user.tokenVersion);
+    const hashedRefresh = await bcrypt.hash(refreshToken, 10);
 
     await prisma.user.update({
       where: { id: userId },


### PR DESCRIPTION
Team number : Team 187
closes #57 
## Summary
Fixes a runtime issue in the token generation flow where `hashedRefresh` was referenced before being defined.

## Changes Made
- Generated refresh token properly
- Hashed the refresh token before database update
- Ensured authentication flow does not crash
- Code-only change; no UI modifications were required, so no screenshots are included.

## Impact
This resolves login/signup failures caused by the undefined variable and improves authentication stability.

## Testing
- Verified login flow
- Verified signup flow
- Confirmed refresh token is stored correctly